### PR TITLE
Add dashboard to guest area (/account)

### DIFF
--- a/app/_components/BookingCard.tsx
+++ b/app/_components/BookingCard.tsx
@@ -1,9 +1,12 @@
+'use client';
+
 import Image from 'next/image';
 import Link from 'next/link';
+import { FaPencilAlt } from 'react-icons/fa';
 import { format, formatDistance, isPast, isToday, parseISO } from 'date-fns';
+import { deleteBooking } from '../_lib/actions';
 import { GuestBooking } from '../_types/GuestBooking';
 import DeleteBooking from '@/app/_components/DeleteBooking';
-import { FaPencilAlt } from 'react-icons/fa';
 
 export const formatDistanceFromNow = (dateStr: string) =>
   formatDistance(parseISO(dateStr), new Date(), {
@@ -12,10 +15,16 @@ export const formatDistanceFromNow = (dateStr: string) =>
 
 type BookingCardProps = {
   booking: GuestBooking;
-  onDelete: (bookingId: GuestBooking['id']) => Promise<void>;
+  onOptimisticDelete?: (bookingId: GuestBooking['id']) => Promise<void>;
 };
 
-export default function BookingCard({ booking, onDelete }: BookingCardProps) {
+export default function BookingCard({
+  booking,
+  onOptimisticDelete,
+}: BookingCardProps) {
+  const handleDelete = async (bookingId: GuestBooking['id']) =>
+    await deleteBooking(bookingId);
+
   return (
     <div className='flex border border-primary-400 rounded-lg'>
       <div className='relative h-32 aspect-square'>
@@ -75,7 +84,10 @@ export default function BookingCard({ booking, onDelete }: BookingCardProps) {
               <FaPencilAlt className='h-4 w-4 text-primary-500 group-hover:text-primary-200 transition-colors' />
               <span className='mt-1'>Update</span>
             </Link>
-            <DeleteBooking bookingId={booking.id} onDelete={onDelete} />
+            <DeleteBooking
+              bookingId={booking.id}
+              onDelete={onOptimisticDelete ?? handleDelete}
+            />
           </>
         )}
       </div>

--- a/app/_components/BookingList.tsx
+++ b/app/_components/BookingList.tsx
@@ -25,7 +25,7 @@ export default function BookingList({ bookings }: BookingListProps) {
   };
 
   return (
-    <ul className='space-y-6'>
+    <ul className='space-y-6 overflow-x-auto'>
       {optimisticBookings.map(booking => (
         <BookingCard
           booking={booking}

--- a/app/_components/BookingList.tsx
+++ b/app/_components/BookingList.tsx
@@ -19,7 +19,7 @@ export default function BookingList({ bookings }: BookingListProps) {
     }
   );
 
-  const handleDelete = async (bookingId: GuestBooking['id']) => {
+  const handleOptimisticDelete = async (bookingId: GuestBooking['id']) => {
     optimisticDelete(bookingId);
     await deleteBooking(bookingId);
   };
@@ -29,7 +29,7 @@ export default function BookingList({ bookings }: BookingListProps) {
       {optimisticBookings.map(booking => (
         <BookingCard
           booking={booking}
-          onDelete={handleDelete}
+          onOptimisticDelete={handleOptimisticDelete}
           key={booking.id}
         />
       ))}

--- a/app/_lib/actions.ts
+++ b/app/_lib/actions.ts
@@ -84,7 +84,7 @@ export async function createBooking(
   }
 
   revalidatePath(`/cabins/${newBookingData.cabinId}`);
-  redirect('/cabins/acknowledgement');
+  redirect('/booking-confirmation');
 }
 
 export async function updateBooking(formData: FormData) {

--- a/app/account/bookings/page.tsx
+++ b/app/account/bookings/page.tsx
@@ -25,7 +25,7 @@ export default async function BookingsPage() {
         <p>
           You don’t have any bookings at the moment. Explore our{' '}
           <Link
-            className='underline underline-offset-8 font-medium text-accent-700'
+            className='inline-block text-accent-700 font-medium border-b border-accent-300 hover:border-accent-700 transition-colors'
             href='/cabins'
           >
             luxury cabins &rarr;

--- a/app/account/bookings/page.tsx
+++ b/app/account/bookings/page.tsx
@@ -16,7 +16,7 @@ export default async function BookingsPage() {
   );
 
   return (
-    <div>
+    <>
       <h2 className='font-semibold text-xl text-accent-700 mb-7'>
         Your bookings
       </h2>
@@ -34,6 +34,6 @@ export default async function BookingsPage() {
       ) : (
         <BookingList bookings={bookings} />
       )}
-    </div>
+    </>
   );
 }

--- a/app/account/layout.tsx
+++ b/app/account/layout.tsx
@@ -7,9 +7,9 @@ type AccountLayoutProps = {
 
 export default function AccountLayout({ children }: AccountLayoutProps) {
   return (
-    <div className='grid grid-cols-[16rem_1fr] h-full gap-12'>
+    <div className='grid grid-cols-[16rem_1fr] h-[78.6vh] gap-12'>
       <SideNavigation />
-      <div className='py-1'>{children}</div>
+      <div className='py-1 flex flex-col h-[78.6vh]'>{children}</div>
     </div>
   );
 }

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,5 +1,9 @@
+import Link from 'next/link';
 import { Metadata } from 'next';
+import { compareAsc, compareDesc, isAfter, isBefore, parseISO } from 'date-fns';
 import { auth } from '../_lib/auth';
+import { getBookings } from '../_lib/data-service';
+import BookingCard from '../_components/BookingCard';
 
 export const metadata: Metadata = {
   title: 'Guest area',
@@ -8,10 +12,65 @@ export const metadata: Metadata = {
 export default async function AccountPage() {
   const session = await auth();
   const firstName: string = session?.user?.name?.split(' ').at(0) ?? '';
+  const bookings = await getBookings(session?.user?.guestId as number);
+
+  const upcomingBooking =
+    bookings
+      .filter(booking => isAfter(parseISO(booking.startDate), new Date()))
+      .sort((a, b) => compareAsc(parseISO(a.startDate), parseISO(b.startDate)))
+      .at(0) ?? null;
+
+  const lastBooking =
+    bookings
+      .filter(booking => isBefore(parseISO(booking.endDate), new Date()))
+      .sort((a, b) => compareDesc(parseISO(a.endDate), parseISO(b.endDate)))
+      .at(0) ?? null;
 
   return (
-    <h2 className='font-semibold text-xl text-accent-700 mb-7'>
-      Welcome, {firstName}
-    </h2>
+    <div>
+      <h2 className='font-semibold text-xl text-accent-700 mb-7'>
+        Welcome, {firstName}
+      </h2>
+
+      <div className='flex flex-col gap-16'>
+        {upcomingBooking ? (
+          <section>
+            <h3 className='text-lg'>Upcoming stay</h3>
+            <BookingCard booking={upcomingBooking} />
+          </section>
+        ) : (
+          <p>
+            You don&apos;t have upcoming stays.{' '}
+            <Link href='/cabins'>Book one</Link>
+          </p>
+        )}
+
+        {lastBooking ? (
+          <section>
+            <h3 className='text-lg'>Last stay</h3>
+            <BookingCard booking={lastBooking} />
+          </section>
+        ) : (
+          <p>You don&apos;t have previous stays with us.</p>
+        )}
+
+        <section>
+          <ul>
+            <li>
+              <Link href='/account/bookings'>Manage your bookings</Link>
+            </li>
+            <li>
+              <Link href='/account/profile'>Update your profile</Link>
+            </li>
+            <li>
+              <Link href='/contact'>Contact support</Link>
+            </li>
+            <li>
+              <Link href=''>Check FAQ</Link>
+            </li>
+          </ul>
+        </section>
+      </div>
+    </div>
   );
 }

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -27,50 +27,84 @@ export default async function AccountPage() {
       .at(0) ?? null;
 
   return (
-    <div>
+    <>
       <h2 className='font-semibold text-xl text-accent-700 mb-7'>
         Welcome, {firstName}
       </h2>
 
-      <div className='flex flex-col gap-16'>
-        {upcomingBooking ? (
-          <section>
-            <h3 className='text-lg'>Upcoming stay</h3>
-            <BookingCard booking={upcomingBooking} />
-          </section>
-        ) : (
-          <p>
-            You don&apos;t have upcoming stays.{' '}
-            <Link href='/cabins'>Book one</Link>
-          </p>
-        )}
+      <div className='flex flex-col flex-grow gap-16'>
+        <section className='flex flex-col gap-12'>
+          <div className='flex flex-col gap-2'>
+            <h3 className='text-lg font-semibold'>Upcoming stay</h3>
 
-        {lastBooking ? (
-          <section>
-            <h3 className='text-lg'>Last stay</h3>
-            <BookingCard booking={lastBooking} />
-          </section>
-        ) : (
-          <p>You don&apos;t have previous stays with us.</p>
-        )}
+            {upcomingBooking ? (
+              <BookingCard booking={upcomingBooking} />
+            ) : (
+              <p>
+                You don&apos;t have upcoming stays.{' '}
+                <Link href='/cabins'>Book one</Link>
+              </p>
+            )}
+          </div>
 
-        <section>
-          <ul>
+          <div className='flex flex-col gap-2'>
+            <h3 className='text-lg font-semibold'>
+              {lastBooking ? 'Last stay' : 'Welcome to Your First Stay!'}
+            </h3>
+
+            {lastBooking ? (
+              <BookingCard booking={lastBooking} />
+            ) : (
+              <p>
+                It looks like this is your first visit with us! We hope you
+                enjoy your time at our resort. We’d love to hear your thoughts,
+                so please consider leaving a review when your stay is complete.
+              </p>
+            )}
+          </div>
+        </section>
+
+        <section className='mt-auto'>
+          <ul className='flex items-center justify-center gap-16 text-lg'>
             <li>
-              <Link href='/account/bookings'>Manage your bookings</Link>
+              <Link
+                href='/account/bookings'
+                role='button'
+                className='text-accent-700 font-medium border-b border-accent-300 hover:border-accent-700 transition-colors'
+              >
+                Manage your bookings
+              </Link>
             </li>
             <li>
-              <Link href='/account/profile'>Update your profile</Link>
+              <Link
+                href='/account/profile'
+                role='button'
+                className='text-accent-700 font-medium border-b border-accent-300 hover:border-accent-700 transition-colors'
+              >
+                Update your profile
+              </Link>
             </li>
             <li>
-              <Link href='/contact'>Contact support</Link>
+              <Link
+                href='/contact'
+                role='button'
+                className='text-accent-700 font-medium border-b border-accent-300 hover:border-accent-700 transition-colors'
+              >
+                Contact support
+              </Link>
             </li>
             <li>
-              <Link href=''>Check FAQ</Link>
+              <Link
+                href=''
+                role='button'
+                className='text-accent-700 font-medium border-b border-accent-300 hover:border-accent-700 transition-colors'
+              >
+                Check FAQ
+              </Link>
             </li>
           </ul>
         </section>
       </div>
-    </div>
+    </>
   );
 }

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -32,79 +32,118 @@ export default async function AccountPage() {
         Welcome, {firstName}
       </h2>
 
-      <div className='flex flex-col flex-grow gap-16'>
-        <section className='flex flex-col gap-12'>
-          <div className='flex flex-col gap-2'>
-            <h3 className='text-lg font-semibold'>Upcoming stay</h3>
+      <div className='flex flex-col flex-grow gap-8 overflow-x-auto'>
+        <section className='flex flex-col gap-1'>
+          <h3 className='text-lg font-semibold'>Upcoming stay</h3>
 
-            {upcomingBooking ? (
-              <BookingCard booking={upcomingBooking} />
-            ) : (
-              <p>
-                You don&apos;t have upcoming stays.{' '}
-                <Link href='/cabins'>Book one</Link>
-              </p>
-            )}
-          </div>
-
-          <div className='flex flex-col gap-2'>
-            <h3 className='text-lg font-semibold'>
-              {lastBooking ? 'Last stay' : 'Welcome to Your First Stay!'}
-            </h3>
-
-            {lastBooking ? (
-              <BookingCard booking={lastBooking} />
-            ) : (
-              <p>
-                It looks like this is your first visit with us! We hope you
-                enjoy your time at our resort. We’d love to hear your thoughts,
-                so please consider leaving a review when your stay is complete.
-              </p>
-            )}
-          </div>
+          {upcomingBooking ? (
+            <BookingCard booking={upcomingBooking} />
+          ) : (
+            <p>
+              You currently have no upcoming stays. Why not{' '}
+              <Link
+                href='/cabins'
+                className='inline-block text-accent-700 font-medium border-b border-accent-300 hover:border-accent-700 transition-colors'
+              >
+                book your next getaway
+              </Link>{' '}
+              with us today?
+            </p>
+          )}
         </section>
 
-        <section className='mt-auto'>
-          <ul className='flex items-center justify-center gap-16 text-lg'>
-            <li>
-              <Link
-                href='/account/bookings'
-                role='button'
-                className='text-accent-700 font-medium border-b border-accent-300 hover:border-accent-700 transition-colors'
-              >
-                Manage your bookings
-              </Link>
-            </li>
-            <li>
-              <Link
-                href='/account/profile'
-                role='button'
-                className='text-accent-700 font-medium border-b border-accent-300 hover:border-accent-700 transition-colors'
-              >
-                Update your profile
-              </Link>
-            </li>
-            <li>
-              <Link
-                href='/contact'
-                role='button'
-                className='text-accent-700 font-medium border-b border-accent-300 hover:border-accent-700 transition-colors'
-              >
-                Contact support
-              </Link>
-            </li>
-            <li>
-              <Link
-                href=''
-                role='button'
-                className='text-accent-700 font-medium border-b border-accent-300 hover:border-accent-700 transition-colors'
-              >
-                Check FAQ
-              </Link>
-            </li>
-          </ul>
+        <section className='flex flex-col gap-1'>
+          <h3 className='text-lg font-semibold'>
+            <span
+              className={`${!lastBooking && 'line-through text-primary-400'}`}
+            >
+              Last stay
+            </span>
+            {!lastBooking && ' Welcome to your first stay!'}
+          </h3>
+
+          {lastBooking ? (
+            <BookingCard booking={lastBooking} />
+          ) : (
+            <p>
+              It looks like this is going to be your first visit with us! We
+              hope you enjoy your time at our resort. We’d love to hear your
+              thoughts, so please consider leaving a review on TripAdvisor,
+              Google and our social media, when your stay is complete.
+            </p>
+          )}
+        </section>
+
+        <section className='flex flex-col gap-1'>
+          <h3 className='text-lg font-semibold'>Upcoming events</h3>
+          <p>
+            Join us for a sunset yoga session by the lake, happening next Friday
+            at 6 PM.
+          </p>
+          <Link
+            href=''
+            className='w-fit text-accent-700 font-medium border-b border-accent-300 hover:border-accent-700 transition-colors'
+          >
+            View all events
+          </Link>
+        </section>
+
+        <section className='flex flex-col gap-1'>
+          <h3 className='text-lg font-semibold'>Exclusive offers</h3>
+          <p>
+            {!lastBooking && !upcomingBooking
+              ? 'Enjoy a special 15% discount on your first stay when you book within the next 7 days! Don’t miss out on this exclusive offer!'
+              : 'We invite you to explore our offers page to see if you qualify for discounts on your stay or exciting attractions. Take advantage of these great deals!'}
+          </p>
+          <Link
+            href=''
+            className='w-fit text-accent-700 font-medium border-b border-accent-300 hover:border-accent-700 transition-colors'
+          >
+            Check offers
+          </Link>
         </section>
       </div>
+
+      <footer className='mt-auto pt-7 uppercase'>
+        <ul className='flex items-center justify-center gap-16 text-base'>
+          <li>
+            <Link
+              href='/account/bookings'
+              role='button'
+              className='block text-accent-700 font-medium border-b-2 border-transparent hover:border-accent-700 transition-colors'
+            >
+              Manage your bookings
+            </Link>
+          </li>
+          <li>
+            <Link
+              href='/account/profile'
+              role='button'
+              className='block text-accent-700 font-medium border-b-2 border-transparent hover:border-accent-700 transition-colors'
+            >
+              Update your profile
+            </Link>
+          </li>
+          <li>
+            <Link
+              href='/contact'
+              role='button'
+              className='block text-accent-700 font-medium border-b-2 border-transparent hover:border-accent-700 transition-colors'
+            >
+              Contact support
+            </Link>
+          </li>
+          <li>
+            <Link
+              href=''
+              role='button'
+              className='block text-accent-700 font-medium border-b-2 border-transparent hover:border-accent-700 transition-colors'
+            >
+              Check FAQ
+            </Link>
+          </li>
+        </ul>
+      </footer>
     </>
   );
 }

--- a/app/booking-confirmation/page.tsx
+++ b/app/booking-confirmation/page.tsx
@@ -1,12 +1,12 @@
 import Link from 'next/link';
 
-export default function AcknowledgementPage() {
+export default function BookingConfirmationPage() {
   return (
     <div className='text-center space-y-6 mt-4'>
       <h1 className='text-2xl font-semibold'>Thank you for your booking!</h1>
       <Link
         href='/account/bookings'
-        className='underline underline-offset-8 font-medium text-accent-700 inline-block'
+        className='inline-block text-accent-700 font-medium border-b border-accent-300 hover:border-accent-700 transition-colors'
       >
         Manage your bookings &rarr;
       </Link>


### PR DESCRIPTION
**What's been changed**: Dashboard has been added to /account with next, last stay, offers, bookings, and a few navigation links. Layout on /account has been adjusted to be always 100vh. Acknowledgement page name has been changed to booking-confirmation and moved back one level.

**How to test it?**: Just review whole UI's, pages etc. When creating booking it should move you to booking-confirmation instead of acknowledgement page. Layout on /account should always be on 100vh.

**To be added**: Responsive design. Connect links on /account to actual links, now they are just placeholders.